### PR TITLE
set seed, restore reporting, fix bugs

### DIFF
--- a/ABM_CE_PV_ConsumerAgents.py
+++ b/ABM_CE_PV_ConsumerAgents.py
@@ -94,6 +94,7 @@ class Consumers(Agent):
         self.number_product_EoL = 0
         self.number_used_product_EoL = 0
         self.tot_prod_EoL = 0
+        self.tot_prod_EoL_m2 = 0  # deprecated: waste now tracked in metric tons
         self.number_product_repaired = 0
         self.number_product_sold = 0
         self.number_product_recycled = 0
@@ -151,6 +152,10 @@ class Consumers(Agent):
 
         _pca_merged_dir = os.path.join(
             os.path.dirname(__file__), "PV_ICE", "TEMP", "PCA_merged")
+        # Old PV ICE per-PCA dataOut results live in the PCA directory (only the
+        # merged datain files are staged in PCA_merged).
+        _pca_dataout_dir = os.path.join(
+            os.path.dirname(__file__), "PV_ICE", "TEMP", "PCA")
         # NOTE: old PV ICE results — kept for W→m² ratio
         # (Yearly_Sum_Area_atEOL / Yearly_Sum_Power_atEOL) used in
         # mass_per_function_model and as the conversion basis for the synthetic
@@ -158,7 +163,7 @@ class Consumers(Agent):
         # self.pv_ice_waste_df (consolidated metric-ton file) instead.
         self.data_out_pca = pd.read_csv(
             os.path.join(
-                _pca_merged_dir,
+                _pca_dataout_dir,
                 f"dataOut_95-by-35.Adv_{self.pca}_.csv",
             )
         )
@@ -1541,18 +1546,25 @@ class Consumers(Agent):
             if regulator_thresholds[self.generator_size].max_storage_kg is not None:
                 self.max_storage_hazardous_kg = regulator_thresholds[self.generator_size].max_storage_kg
 
-    def _assign_closest_recycler(self, distance_df: pd.DataFrame) -> int:
+    def _assign_closest_recycler(self, distance_df: pd.DataFrame,
+                                 base_node_id: int) -> int:
         """
         Return the node ID of the closest recycler in distance_df.
+
+        Recycler node ids are assigned positionally: the row at position p in
+        distance_df corresponds to node ``base_node_id + p``. This uses row
+        identity (not 'Recycler Name') so distinct facilities that share a name
+        are disambiguated correctly.
         Parameters:
         distance_df (pd.DataFrame): Distance DataFrame with a 'Recycler Name'
             column and consumer identifier columns.
+        base_node_id (int): Node id of this frame's first (row 0) recycler.
         Returns:
         int: Node ID of the closest recycler.
         """
         dist_col: pd.Series = distance_df[str(self.agent_identifier)]
-        closest_name: str = distance_df.loc[dist_col.idxmin(), "Recycler Name"]
-        return self.model.recycler_name_to_id[closest_name]
+        row_pos: int = distance_df.index.get_loc(dist_col.idxmin())
+        return base_node_id + row_pos
 
     def set_recycling_transport_distance_and_costs(self):
         """
@@ -1565,7 +1577,7 @@ class Consumers(Agent):
         self.recyc_transp_cost = self.recyc_transp_dist * \
             self.model.get_transportation_cost(self.hazardous)
         self.recycling_facility_id = self._assign_closest_recycler(
-            self.model.recycler_distance_df)
+            self.model.recycler_distance_df, self.model.num_consumers)
         self.hazardous_recycler_facility_id = self.recycling_facility_id
 
     def set_universal_waste_recycling_transport_distance_and_costs(self):
@@ -1578,7 +1590,8 @@ class Consumers(Agent):
         self.universal_waste_recyc_transp_cost = self.universal_waste_recyc_transp_dist * \
             self.model.get_transportation_cost()
         self.universal_waste_recycler_facility_id = self._assign_closest_recycler(
-            self.model.universal_waste_recycler_distance_df)
+            self.model.universal_waste_recycler_distance_df,
+            self.model.num_consumers + self.model.num_regular_recyclers)
 
     def get_active_recycling_facility_id(self) -> int:
         """

--- a/ABM_CE_PV_Model.py
+++ b/ABM_CE_PV_Model.py
@@ -237,6 +237,12 @@ class ABM_CE_PV(Model):
         file_name = config.legacy_data.file_name.model_dump(by_alias=True)
 
         self.seed = seed
+        # Seed every RNG the model relies on. Mesa's super().__init__(seed=...)
+        # only seeds self.random; agent logic also uses the global random module
+        # and numpy, so seed those too for reproducible per-run results.
+        if seed is not None:
+            random.seed(seed)
+            np.random.seed(seed)
         self.timestep = timestep
         self.rtn = rtn
         self.solar_cycle = solar_cycle
@@ -279,6 +285,15 @@ class ABM_CE_PV(Model):
             self.reeds_data = data.reeds_data.copy()
             self.uspvdb = self.uspvdb[
                 self.uspvdb["PCA"] != PCA_MISSING_VALUE
+            ].copy()
+            # PV ICE waste data is the authoritative waste source for this
+            # simulation. Restrict sites to PCAs that have a waste time series
+            # (e.g. drop p119, p122): sites without waste data would create
+            # agents with no waste to process and fail downstream date-based
+            # waste lookups on multi-step runs.
+            _waste_pcas = set(data.pvice_waste_eol_df["pca"].unique())
+            self.uspvdb = self.uspvdb[
+                self.uspvdb["PCA"].isin(_waste_pcas)
             ].copy()
 
         GIS = data.gis_centroids.copy()
@@ -782,76 +797,31 @@ class ABM_CE_PV(Model):
             self.agent_pca_map = self.create_agent_pca_map(self.num_consumers)
         elif self.consumer_agent_resolution is ConsumerAgentResolution.SITE:
             self.agent_site_map = self.create_agent_site_map()
-        recycler_data_df = (
-            self.recycling_costs_df
-            if self.rtn
-            else self.recycler_distance_df
+        # Recycler node ids are assigned POSITIONALLY: combined-row-index j
+        # across [regular ++ universal-waste] distance frames maps to node
+        # num_consumers + j. Recycler names are NOT unique (duplicate names are
+        # distinct physical facilities at different locations), so a name->id
+        # dict would collapse them and mis-route/lose facilities. Counts use
+        # ROW counts, not .unique().
+        regular_recycler_names = list(
+            self.recycler_distance_df["Recycler Name"].astype(str)
+        )
+        universal_waste_recycler_names = list(
+            self.universal_waste_recycler_distance_df["Recycler Name"].astype(str)
         )
 
-        regular_recycler_names = (
-            recycler_data_df["Recycler Name"]
-            .dropna()
-            .astype(str)
-            .unique()
-            .tolist()
+        # Facility name per node offset, in creation/row order (regular then UW).
+        self.recycler_facilities: list[str] = (
+            regular_recycler_names + universal_waste_recycler_names
         )
+        self.num_regular_recyclers = len(regular_recycler_names)
+        self.num_universal_waste_recyclers = len(universal_waste_recycler_names)
+        self.num_recyclers = len(self.recycler_facilities)
 
-        universal_waste_recycler_names = (
-            self.universal_waste_recycler_distance_df[
-                "Recycler Name"
-            ]
-            .dropna()
-            .astype(str)
-            .unique()
-            .tolist()
-        )
-
-        # Remove names that appear in both datasets while preserving order.
-        self.recycler_names = list(
-            dict.fromkeys(
-                regular_recycler_names
-                + universal_waste_recycler_names
-            )
-        )
-
-        # The agent count must exactly match the number of names.
-        self.num_recyclers = len(self.recycler_names)
-
-        # Keep a separate mutable list for Recyclers.__init__.
-        self.available_recycler_names = (
-            self.recycler_names.copy()
-        )
-
-        self.recycler_name_to_id: dict[str, int] = {
-            name: self.num_consumers + index
-            for index, name in enumerate(
-                reversed(self.recycler_names)
-            )
-        }
-
-        first_recycler_id = self.num_consumers
-        last_recycler_id = (
-            self.num_consumers
-            + self.num_recyclers
-            - 1
-        )
-
-        invalid_recycler_ids = {
-            name: recycler_id
-            for name, recycler_id
-            in self.recycler_name_to_id.items()
-            if not (
-                first_recycler_id
-                <= recycler_id
-                <= last_recycler_id
-            )
-        }
-
-        if invalid_recycler_ids:
-            raise ValueError(
-                "Recycler names were assigned IDs outside "
-                f"the recycler range: {invalid_recycler_ids}"
-            )
+        assert (
+            self.num_recyclers
+            == self.num_regular_recyclers + self.num_universal_waste_recyclers
+        ), "recycler facility count mismatch"
 
         self.num_producers = num_producers
         self.num_prod_n_recyc = (
@@ -883,6 +853,10 @@ class ABM_CE_PV(Model):
             valid_pcas = self.data[self.data['State'].isin(self.model_states)]['PCA'].unique().tolist()
         _pca_merged_dir = os.path.join(
             os.path.dirname(__file__), "PV_ICE", "TEMP", "PCA_merged")
+        # Old PV ICE per-PCA dataOut results live in the PCA directory (only the
+        # merged datain files are staged in PCA_merged).
+        _pca_dataout_dir = os.path.join(
+            os.path.dirname(__file__), "PV_ICE", "TEMP", "PCA")
         for pca in valid_pcas:
             # Merged datain file: Solar Futures (2010–2025) + ReEDS StdScen24
             # (2026+); used for installed capacity history (total_number_product).
@@ -893,7 +867,7 @@ class ABM_CE_PV(Model):
             # NOTE: old PV ICE results — used for product_average_wght baseline
             subset_df_init_cap_out = pd.read_csv(
                 os.path.join(
-                    _pca_merged_dir,
+                    _pca_dataout_dir,
                     f"dataOut_95-by-35.Adv_{pca}_.csv",
                 )
             )
@@ -1419,7 +1393,7 @@ class ABM_CE_PV(Model):
         """
         if network == "small-world":
             return nx.watts_strogatz_graph(nodes, node_degree, rewiring_prob,
-                                           seed=random.seed(self.seed))
+                                           seed=self.seed)
         elif network == "complete graph":
             return nx.complete_graph(nodes)
         if network == "random":

--- a/ABM_CE_PV_RecyclerAgents.py
+++ b/ABM_CE_PV_RecyclerAgents.py
@@ -67,8 +67,9 @@ class Recyclers(Agent):
         self.symbiosis = False
         self.agent_i = self.unique_id - self.model.num_consumers
         self.recycler_costs = 0
-        # self.recycler_name = self.model.recycler_names.pop()
-        self.recycler_name = (self.model.available_recycler_names.pop())
+        # Recycler node ids are assigned positionally: this recycler's name is
+        # its offset into the model's row-ordered facility list.
+        self.recycler_name = self.model.recycler_facilities[self.agent_i]
         self.hazardous = False
         self.universal_waste = False
         self.verified = False

--- a/absice/runner.py
+++ b/absice/runner.py
@@ -462,7 +462,13 @@ def _execute_and_save(
     output_path: Path,
 ) -> None:
     """
-    Instantiate the model, run all steps, and save model-level results.
+    Instantiate the model, run all steps, and save model- and agent-level
+    results.
+
+    Two CSVs are written next to each other:
+
+    - ``output_path`` (``Results_model_run_<id>.csv``): model-level reporters.
+    - ``Results_agents_consumers_run_<id>.csv``: per-consumer agent reporters.
 
     Parameters
     ----------
@@ -471,8 +477,11 @@ def _execute_and_save(
     data
         All datasets loaded by ``DataLoader``.
     output_path
-        CSV destination for the model-level DataCollector output.
+        CSV destination for the model-level DataCollector output. The
+        consumer agent CSV is derived from this path.
     """
+    from ABM_CE_PV_ConsumerAgents import Consumers
+
     model = ABM_CE_PV(
         config=config,
         data=data,
@@ -481,13 +490,22 @@ def _execute_and_save(
     for _ in range(config.run.last_step):
         model.step()
 
-    results: pd.DataFrame = (
-        model.datacollector.get_model_vars_dataframe()
-    )
-
     output_path.parent.mkdir(
         parents=True,
         exist_ok=True,
     )
 
+    results: pd.DataFrame = (
+        model.datacollector.get_model_vars_dataframe()
+    )
     results.to_csv(output_path)
+
+    # Agent-level (consumer) results. Filename mirrors the model output so both
+    # share the same run id, e.g. Results_agents_consumers_run_0.csv.
+    consumer_results: pd.DataFrame = (
+        model.datacollector.get_agenttype_vars_dataframe(Consumers)
+    )
+    consumer_output_path = output_path.parent / output_path.name.replace(
+        "Results_model_run_", "Results_agents_consumers_run_"
+    )
+    consumer_results.to_csv(consumer_output_path)


### PR DESCRIPTION
Tested and verified changes made to the new data and command line interface. Some issues that were fixed:

- One of the agent level reporters was disabled. Added that back in.
-  **Seeding bugs** - ABM_CE_PV_Model.py:1390 is a bug:`nx.watts_strogatz_graph(nodes, node_degree, rewiring_prob, seed=random.seed(self.seed))`
`random.seed(...) ` returns `None,` so this passes `seed=None` to NetworkX — the graph is not seeded, and it also globally reseeds Python's random as a side effect. Should be `seed=self.seed`. Also, NumPy and Python's random package isn't seeded. Line 1800 uses `np.random.weibull(...) `and other code uses `np.random`, but nothing calls `np.random.seed(...)` / uses a seeded `np.random.Generator`. Mesa's `super().__init__(seed=...)` only seeds `self.random `(the model's own `random.Random`), not the global random or numpy. So runs would never be reproducible even if using the same seed.

Some exiting issues that were fixed (these were not introduced by the latest changes)

- **Mismatched PCAs** - The latest PV-ICE data does not have certain PCAs like p119, p122 which were previously there and are part of the USPVDB file. This was causing some agents to not produce any waste. Added a filtering step to only keep those sites that have corresponding PV-ICE entries.
- **Duplicate names of recyclers** - Recycler names are NOT unique (duplicate names are distinct physical facilities at different locations). So using recycler names to route waste to recyclers would not always pick the closest recycler. This PR changes the agent -> recycler id lookup from the name to a tuple (row_id, name).